### PR TITLE
Fix ModuleNotFoundError in plotting.py

### DIFF
--- a/MTFLibrary/EMLibrary/plotting.py
+++ b/MTFLibrary/EMLibrary/plotting.py
@@ -2,7 +2,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
 from ..taylor_function import MultivariateTaylorFunctionBase
-from ..mtf_base import MTF
 from .biot_savart import serial_biot_savart
 
 class Coil:


### PR DESCRIPTION
This commit removes an unused and incorrect relative import (`from ..mtf_base import MTF`) from `MTFLibrary/EMLibrary/plotting.py`.

This import was causing a `ModuleNotFoundError` when running the `Field_Plotting_Demo.ipynb` notebook, as the relative import path was invalid in that context. The import was unnecessary for the functionality of the `plotting` module and was a remnant from previous development.

With this fix, the demo notebook now runs without errors.