### PR TITLE
feat: Configure Read the Docs for automatic documentation builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,23 +1,27 @@
+# .readthedocs.yaml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
 version: 2
 
-# Set the OS, Python version, and other tools you might need
+# Set the version of Python and other tools you might need
 build:
   os: ubuntu-24.04
   tools:
     python: "3.13"
 
-# Build documentation in the "docs/" directory with Sphinx
+# Build documentation in the docs/ directory with Sphinx
 sphinx:
-   configuration: docs/conf.py
+  configuration: docs/conf.py
 
-# Optionally, but recommended,
-# declare the Python requirements required to build your documentation
+# Optionally build the docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#    install:
-#    - requirements: docs/requirements.txt
-        
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+sphinx-rtd-theme
+.


### PR DESCRIPTION
This commit sets up the necessary configuration for building the project's documentation automatically on Read the Docs.

- A `.readthedocs.yaml` file is added to configure the build environment, specifying the OS, Python version, and Sphinx configuration path.
- A `docs/requirements.txt` file is created to manage the Python dependencies needed for the documentation build, including Sphinx, the Read the Docs theme, and the local `mtflib` package itself.