### PR TITLE
Fix NameError in run_all_demos.py

### DIFF
--- a/run_all_demos.py
+++ b/run_all_demos.py
@@ -313,6 +313,9 @@ import sys
 # Configure matplotlib for non-interactive backend
 matplotlib.use('Agg')
 
+# Define demo_name for use in filenames
+demo_name = "{demo_name}"
+
 # Global figure counter for sequential naming
 _figure_counter = 1
 


### PR DESCRIPTION
The `run_all_demos.py` script failed when running Jupyter notebook demos because the `demo_name` variable was not defined in the scope of the dynamically generated matplotlib wrapper script.

This was caused by an issue in the `create_matplotlib_wrapper` function, where the `demo_name` variable was not being correctly passed into the wrapper's scope.

This commit fixes the issue by defining `demo_name` as a global variable within the wrapper script's content string. This makes the variable available to the `save_figure_as_png` function and allows the demos to run successfully.