### PR TITLE
Prepare for release 1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.3] - 2025-09-12
+
+### Changed
+- General bug fixes and performance improvements.
+
 ## [1.4.0] - 2025-09-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,15 @@ A Python library for creating, manipulating, and composing Multivariate Taylor F
 
 ## Installation
 
-You can install `mtflib` directly from the source repository using pip. Ensure you have a C++17 compliant compiler (e.g., GCC, Clang, MSVC) for building the backend extensions.
+The recommended way to install `mtflib` is from PyPI:
+
+```bash
+pip install mtflib
+```
+
+### Installation from Source
+
+Alternatively, you can install `mtflib` directly from the source repository using pip. Ensure you have a C++17 compliant compiler (e.g., GCC, Clang, MSVC) for building the backend extensions.
 
 ```bash
 pip install .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,8 +18,8 @@ project = "mtflib"
 copyright = "2025, Shashikant Manikonda"
 author = "Shashikant Manikonda"
 
-version = "2.0.1"
-release = "2.0.1"
+version = "1.4.3"
+release = "1.4.3"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mtflib"
-version = "1.4.2"
+version = "1.4.3"
 authors = [
     { name="Shashikant Manikonda", email="manikonda@outlook.com" },
 ]


### PR DESCRIPTION
This commit includes the following changes to prepare for the 1.4.3 release:

- Updates the README.md to include PyPI installation instructions.
- Updates the CHANGELOG.md with a new entry for version 1.4.3.
- Bumps the version number to 1.4.3 in pyproject.toml and docs/conf.py.