### PR TITLE
Prepare for release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2025-09-13
+
+### BREAKING CHANGES
+- This is a major release with significant improvements and breaking changes. It is NOT backward compatible with previous versions.
+
+### Added
+- New features and major performance improvements.
+
+### Changed
+- General bug fixes.
+
 ## [1.4.3] - 2025-09-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # mtflib: Multivariate Taylor Function Library
 
+> [!IMPORTANT]
+> **Version 1.5.0 is a major release with significant improvements and breaking changes.**
+> It is NOT backward compatible with previous versions. Please see the [CHANGELOG.md](CHANGELOG.md) for more details.
+
 [![Documentation Status](https://readthedocs.org/projects/mtflibrary/badge/?version=latest)](https://mtflibrary.readthedocs.io/en/latest/?badge=latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,8 +18,8 @@ project = "mtflib"
 copyright = "2025, Shashikant Manikonda"
 author = "Shashikant Manikonda"
 
-version = "1.4.3"
-release = "1.4.3"
+version = "1.5.0"
+release = "1.5.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mtflib"
-version = "1.4.3"
+version = "1.5.0"
 authors = [
     { name="Shashikant Manikonda", email="manikonda@outlook.com" },
 ]


### PR DESCRIPTION
This commit prepares the repository for the release of version 1.5.0.

- Updates the version number to 1.5.0 in `pyproject.toml` and `docs/conf.py`.
- Adds a new section for v1.5.0 to `CHANGELOG.md`.
- Adds a note to `README.md` to inform users about the new major release.